### PR TITLE
Fix fo react select tag

### DIFF
--- a/lib/component.selectfx.js
+++ b/lib/component.selectfx.js
@@ -63,7 +63,7 @@ SelectFx.prototype._init = function () {
 	this.hasDefaultPlaceholder = selectedOpt && selectedOpt.disabled;
 
 	// get selected option (either the first option with attr selected or just the first option)
-	this.selectedOpt = selectedOpt || this.el.querySelector('option');
+	this.selectedOpt = selectedOpt || this.el.querySelector('option[value="' + this.el.value + '"]') || this.el.querySelector('option');
 
 	// create structure
 	this._createSelectEl();


### PR DESCRIPTION
#2

when selected option is not found, it uses select tag's value on querySelector.
